### PR TITLE
Fix README setup instructions for frontend directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,33 +314,32 @@ WalletWise is designed for:
 </div>
 
 ---
-
 ## 🚀 Getting Started
 
 ### Prerequisites
-
 - Node.js (v16+)
-- MongoDB (v5+)
 - npm or yarn
 
-### Installation
+## Installation
+
+### Frontend Setup
+
+The frontend application is located inside the `frontend/` directory.  
+All npm commands must be executed from this directory.
 
 ```bash
 # Clone the repository
 git clone https://github.com/SoumyaMishra-7/WalletWise.git
 
-# Navigate to project directory
-cd WalletWise
+# Navigate to frontend directory
+cd WalletWise/frontend
 
 # Install dependencies
 npm install
 
-# Set up environment variables
-cp .env.example .env
-
-# Run the application
+# Start the development server
 npm start
-```
+
 
 ---
 


### PR DESCRIPTION
This PR fixes an issue where first-time contributors encountered an ENOENT error while running `npm install`.

The README has been updated to clearly document that the frontend lives inside the `frontend/` directory and that npm commands must be run from there.
Fixes #2
