### PR TITLE
fix: implement strict number validation for amount in transactions #15

### DIFF
--- a/backend/routes/transactionRoutes.js
+++ b/backend/routes/transactionRoutes.js
@@ -15,6 +15,13 @@ router.post('/', protect, async (req, res) => {
       return res.status(400).json({ message: 'Type, amount, and category are required' });
     }
 
+    //Validate amount is a number and positive
+    if (typeof amount !== 'number' || isNaN(amount) || amount <= 0) {
+      return res.status(400).json({
+        message: 'Amount must be a valid positive number. Strings are not allowed.'
+      });
+    }
+
     // Validate type
     if (!['income', 'expense'].includes(type)) {
       return res.status(400).json({ message: 'Type must be either income or expense' });


### PR DESCRIPTION
### Description
This PR addresses Issue #15 by adding strict type validation for the `amount` field in the transaction controller. 

Previously, the code only checked for existence and positive values, which allowed string inputs to bypass validation and potentially cause data inconsistency or calculation errors.

### Changes Made
- Added `typeof amount !== 'number'` check to ensure strict numeric types.
- Added `isNaN(amount)` check to prevent invalid mathematical values.
- Maintained existing checks for required fields and positive values.

### How to Verify
1. Send a POST request with `"amount": "100"` (string) -> Expected: 400 Bad Request.
2. Send a POST request with `"amount": 100` (number) -> Expected: 201 Created.

Fixes #15