### PR TITLE
Fix Get Started button text visibility on hover

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -81,17 +81,20 @@ body {
   background: var(--danger-color);
   color: white;
 }
-
 .btn-outline {
   background: transparent;
   border: 2px solid var(--primary-color);
   color: var(--primary-color);
 }
 
-.btn-outline:hover {
-  background: var(--primary-color);
-  color: white;
+.btn-outline:hover,
+.btn-outline:focus {
+  background-color: var(--primary-color);
+  color: var(--white);
 }
+
+
+
 
 /* Form Styles */
 .form-group {


### PR DESCRIPTION
### What was fixed
The "Get Started" button text was not clearly visible on hover.

### Changes made
- Updated hover styles in App.css
- Improved contrast for better readability

### Files changed
- frontend/src/App.css
