### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -67,7 +67,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -717,7 +716,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.28.6.tgz",
       "integrity": "sha512-D+OrJumc9McXNEBI/JmFnc/0uCM2/Y3PEBG3gfV3QIYkKv5pvnpzFrl1kYCrcHJP8nOeFB/SHi1IHz29pNGuew==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
       },
@@ -1601,7 +1599,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.28.6.tgz",
       "integrity": "sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
         "@babel/helper-module-imports": "^7.28.6",
@@ -3752,7 +3749,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -3806,7 +3802,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -4176,7 +4171,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4275,7 +4269,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5196,7 +5189,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5405,7 +5397,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -6258,8 +6249,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -7042,7 +7032,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9816,7 +9805,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -10714,7 +10702,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -12065,7 +12052,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13200,7 +13186,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -13566,7 +13551,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13711,7 +13695,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -13763,7 +13746,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14248,7 +14230,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -14494,7 +14475,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15637,6 +15617,23 @@
         }
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
@@ -15854,7 +15851,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16023,7 +16019,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -16447,7 +16442,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -16519,7 +16513,6 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -16933,7 +16926,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -21,13 +21,61 @@
   --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.1);
   --radius: 10px;
   --transition: all 0.3s ease;
+  --app-bg: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+  --app-text: #333;
+  --surface-color: #ffffff;
+  --surface-muted: #f8fafc;
+  --border-color: #e2e8f0;
+  --overlay-bg: rgba(255, 255, 255, 0.9);
+}
+
+body.theme-light {
+  --app-bg: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+  --app-text: #333;
+  --surface-color: #ffffff;
+  --surface-muted: #f8fafc;
+  --border-color: #e2e8f0;
+  --overlay-bg: rgba(255, 255, 255, 0.9);
+  --bg-app: #f8fafc;
+  --bg-card: #ffffff;
+  --text-main: #0f172a;
+  --text-muted: #64748b;
+  --border-subtle: #f1f5f9;
+  --bg-page: #ffffff;
+  --bg-subtle: #f8fafc;
+  --text-light: #94a3b8;
+  --border-light: #e2e8f0;
+}
+
+body.theme-dark {
+  --app-bg: radial-gradient(circle at top, rgba(30, 41, 59, 0.8), rgba(15, 23, 42, 1));
+  --app-text: #e2e8f0;
+  --surface-color: #111827;
+  --surface-muted: #0f172a;
+  --border-color: #1f2937;
+  --overlay-bg: rgba(2, 6, 23, 0.78);
+  --bg-app: #0f172a;
+  --bg-card: #111827;
+  --text-main: #e2e8f0;
+  --text-muted: #94a3b8;
+  --border-subtle: #1f2937;
+  --bg-page: #0b1120;
+  --bg-subtle: #111827;
+  --text-light: #94a3b8;
+  --border-light: #1f2937;
+  --dark-color: #e2e8f0;
+  --light-color: #1f2937;
+  --white: #111827;
+  --gray-color: #94a3b8;
+  --shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+  --shadow-lg: 0 20px 40px rgba(0, 0, 0, 0.45);
 }
 
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
-  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+  background: var(--app-bg);
   min-height: 100vh;
-  color: #333;
+  color: var(--app-text);
   line-height: 1.6;
 }
 
@@ -64,7 +112,7 @@ body {
 .btn-secondary {
   background: var(--light-color);
   color: var(--dark-color);
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
 }
 
 .btn-secondary:hover {
@@ -105,17 +153,18 @@ body {
   display: block;
   margin-bottom: 8px;
   font-weight: 500;
-  color: #555;
+  color: var(--text-muted);
 }
 
 .form-control {
   width: 100%;
   padding: 12px 16px;
-  border: 2px solid #e1e5e9;
+  border: 2px solid var(--border-color);
   border-radius: var(--radius);
   font-size: 16px;
   transition: var(--transition);
-  background: white;
+  background: var(--surface-color);
+  color: var(--text-main);
 }
 
 .form-control:focus {
@@ -130,7 +179,7 @@ body {
 
 /* Card Styles */
 .card {
-  background: white;
+  background: var(--surface-color);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
   padding: 24px;
@@ -204,7 +253,7 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(255, 255, 255, 0.9);
+  background: var(--overlay-bg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -227,7 +276,7 @@ body {
 }
 
 .modal-content {
-  background: white;
+  background: var(--surface-color);
   border-radius: var(--radius);
   width: 100%;
   max-width: 500px;
@@ -251,7 +300,7 @@ body {
 
 .modal-header {
   padding: 20px 24px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-color);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -462,8 +511,8 @@ body {
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   padding: 0.6rem 1.25rem;
   width: fit-content;
-  background: white;
-  border: 1px solid #e1e5e9;
+  background: var(--surface-color);
+  border: 1px solid var(--border-color);
   border-radius: 9999px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
   letter-spacing: 0.01em;
@@ -472,7 +521,7 @@ body {
 .back-link:hover {
   color: var(--brand-primary, #4361ee);
   border-color: var(--brand-primary, #4361ee);
-  background: white;
+  background: var(--surface-color);
   gap: 0.75rem;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   transform: translateY(-1px);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import { Toaster } from 'react-hot-toast';
 import './App.css';
 import { AuthProvider } from './context/AuthContext';
+import { ThemeProvider } from './context/ThemeContext';
 
 // Import your existing components
 import Homepage from './components/Homepage';
@@ -27,173 +28,175 @@ import PublicRoute from './components/PublicRoute';
 
 function App() {
   return (
-    <AuthProvider>
-      <Router>
-        <div className="app">
-          {/* Toast Notifications */}
-          <Toaster
-            position="top-right"
-            toastOptions={{
-              duration: 3000,
-              style: {
-                background: '#363636',
-                color: '#fff',
-              },
-              success: {
+    <ThemeProvider>
+      <AuthProvider>
+        <Router>
+          <div className="app">
+            {/* Toast Notifications */}
+            <Toaster
+              position="top-right"
+              toastOptions={{
                 duration: 3000,
-                iconTheme: {
-                  primary: '#10b981',
-                  secondary: '#fff',
+                style: {
+                  background: '#363636',
+                  color: '#fff',
                 },
-              },
-              error: {
-                duration: 4000,
-                iconTheme: {
-                  primary: '#ef4444',
-                  secondary: '#fff',
+                success: {
+                  duration: 3000,
+                  iconTheme: {
+                    primary: '#10b981',
+                    secondary: '#fff',
+                  },
                 },
-              },
-            }}
-          />
-
-          <Routes>
-            {/* Public Routes */}
-            <Route path="/" element={<Homepage />} />
-
-            <Route
-              path="/login"
-              element={
-                <PublicRoute>
-                  <Login />
-                </PublicRoute>
-              }
+                error: {
+                  duration: 4000,
+                  iconTheme: {
+                    primary: '#ef4444',
+                    secondary: '#fff',
+                  },
+                },
+              }}
             />
 
-            <Route
-              path="/signup"
-              element={
-                <PublicRoute>
-                  <Signup />
-                </PublicRoute>
-              }
-            />
+            <Routes>
+              {/* Public Routes */}
+              <Route path="/" element={<Homepage />} />
 
-            <Route
-              path="/verify-email"
-              element={
-                <PublicRoute>
-                  <VerifyEmail />
-                </PublicRoute>
-              }
-            />
+              <Route
+                path="/login"
+                element={
+                  <PublicRoute>
+                    <Login />
+                  </PublicRoute>
+                }
+              />
 
-            {/* Protected Routes - Only accessible when logged in */}
-            <Route
-              path="/dashboard"
-              element={
-                <ProtectedRoute>
-                  <Dashboard />
-                </ProtectedRoute>
-              }
-            />
+              <Route
+                path="/signup"
+                element={
+                  <PublicRoute>
+                    <Signup />
+                  </PublicRoute>
+                }
+              />
 
-            {/* NEW: Behaviour Analysis Route */}
-            <Route
-              path="/behaviour-analysis"
-              element={
-                <ProtectedRoute>
-                  <BehaviourDashboard />
-                </ProtectedRoute>
-              }
-            />
+              <Route
+                path="/verify-email"
+                element={
+                  <PublicRoute>
+                    <VerifyEmail />
+                  </PublicRoute>
+                }
+              />
 
-            <Route
-              path="/add-expense"
-              element={
-                <ProtectedRoute>
-                  <AddExpense />
-                </ProtectedRoute>
-              }
-            />
+              {/* Protected Routes - Only accessible when logged in */}
+              <Route
+                path="/dashboard"
+                element={
+                  <ProtectedRoute>
+                    <Dashboard />
+                  </ProtectedRoute>
+                }
+              />
 
-            <Route
-              path="/set-budget"
-              element={
-                <ProtectedRoute>
-                  <SetBudget />
-                </ProtectedRoute>
-              }
-            />
+              {/* NEW: Behaviour Analysis Route */}
+              <Route
+                path="/behaviour-analysis"
+                element={
+                  <ProtectedRoute>
+                    <BehaviourDashboard />
+                  </ProtectedRoute>
+                }
+              />
 
-            <Route
-              path="/saving-goal"
-              element={
-                <ProtectedRoute>
-                  <SavingGoal />
-                </ProtectedRoute>
-              }
-            />
+              <Route
+                path="/add-expense"
+                element={
+                  <ProtectedRoute>
+                    <AddExpense />
+                  </ProtectedRoute>
+                }
+              />
 
-            <Route
-              path="/transactions"
-              element={
-                <ProtectedRoute>
-                  <Transactions />
-                </ProtectedRoute>
-              }
-            />
+              <Route
+                path="/set-budget"
+                element={
+                  <ProtectedRoute>
+                    <SetBudget />
+                  </ProtectedRoute>
+                }
+              />
 
-            <Route
-              path="/budget"
-              element={
-                <ProtectedRoute>
-                  <Budget />
-                </ProtectedRoute>
-              }
-            />
+              <Route
+                path="/saving-goal"
+                element={
+                  <ProtectedRoute>
+                    <SavingGoal />
+                  </ProtectedRoute>
+                }
+              />
 
-            <Route
-              path="/goals"
-              element={
-                <ProtectedRoute>
-                  <Goals />
-                </ProtectedRoute>
-              }
-            />
+              <Route
+                path="/transactions"
+                element={
+                  <ProtectedRoute>
+                    <Transactions />
+                  </ProtectedRoute>
+                }
+              />
 
-            <Route
-              path="/reports"
-              element={
-                <ProtectedRoute>
-                  <Reports />
-                </ProtectedRoute>
-              }
-            />
+              <Route
+                path="/budget"
+                element={
+                  <ProtectedRoute>
+                    <Budget />
+                  </ProtectedRoute>
+                }
+              />
 
-            <Route
-              path="/settings"
-              element={
-                <ProtectedRoute>
-                  <Settings />
-                </ProtectedRoute>
-              }
-            />
+              <Route
+                path="/goals"
+                element={
+                  <ProtectedRoute>
+                    <Goals />
+                  </ProtectedRoute>
+                }
+              />
 
-            <Route
-              path="/profile"
-              element={
-                <ProtectedRoute>
-                  <Profile />
-                </ProtectedRoute>
-              }
-            />
+              <Route
+                path="/reports"
+                element={
+                  <ProtectedRoute>
+                    <Reports />
+                  </ProtectedRoute>
+                }
+              />
 
-            {/* Redirect unknown routes to homepage */}
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </Routes>
-        </div>
-      </Router>
-    </AuthProvider>
+              <Route
+                path="/settings"
+                element={
+                  <ProtectedRoute>
+                    <Settings />
+                  </ProtectedRoute>
+                }
+              />
+
+              <Route
+                path="/profile"
+                element={
+                  <ProtectedRoute>
+                    <Profile />
+                  </ProtectedRoute>
+                }
+              />
+
+              {/* Redirect unknown routes to homepage */}
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
+          </div>
+        </Router>
+      </AuthProvider>
+    </ThemeProvider>
   );
 }
 

--- a/frontend/src/components/AppNavbar.css
+++ b/frontend/src/components/AppNavbar.css
@@ -185,6 +185,32 @@
   display: flex;
   justify-content: flex-end;
   position: relative;
+  gap: 0.75rem;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-card);
+  color: var(--text-main);
+  cursor: pointer;
+  transition: var(--transition-fast);
+  box-shadow: var(--shadow-soft);
+}
+
+.theme-toggle:hover {
+  background: rgba(99, 102, 241, 0.05);
+  border-color: rgba(99, 102, 241, 0.2);
+  transform: translateY(-1px);
+}
+
+.theme-toggle svg {
+  font-size: 1rem;
 }
 
 .user-profile-trigger {

--- a/frontend/src/components/AppNavbar.jsx
+++ b/frontend/src/components/AppNavbar.jsx
@@ -10,9 +10,12 @@ import {
   FaChartPie,
   FaBullseye,
   FaChartBar,
-  FaUser
+  FaUser,
+  FaSun,
+  FaMoon
 } from 'react-icons/fa';
 import { useAuth } from '../context/AuthContext';
+import { useTheme } from '../context/ThemeContext';
 import './AppNavbar.css';
 
 const navItems = [
@@ -26,6 +29,7 @@ const navItems = [
 
 const AppNavbar = () => {
   const { user, logout } = useAuth();
+  const { isDark, toggleTheme } = useTheme();
   const navigate = useNavigate();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [showUserMenu, setShowUserMenu] = useState(false);
@@ -101,6 +105,14 @@ const AppNavbar = () => {
       </nav>
 
       <div className="nav-right" ref={userMenuRef}>
+        <button
+          className="theme-toggle"
+          onClick={toggleTheme}
+          aria-label={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+          type="button"
+        >
+          {isDark ? <FaSun /> : <FaMoon />}
+        </button>
         <button
           className="user-profile-trigger"
           onClick={() => setShowUserMenu((prev) => !prev)}

--- a/frontend/src/components/Auth.css
+++ b/frontend/src/components/Auth.css
@@ -125,7 +125,7 @@
   border-radius: 14px;
   font-size: 16px;
   transition: border-color 0.3s, box-shadow 0.3s, background 0.3s;
-  background: #f8fafc;
+  background: var(--surface-muted);
   color: var(--text-main);
 }
 
@@ -134,7 +134,7 @@
   outline: none;
   border-color: rgba(99, 102, 241, 0.6);
   box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.15);
-  background: #ffffff;
+  background: var(--surface-color);
 }
 
 .password-input {
@@ -239,7 +239,7 @@
 .demo-btn {
   width: 100%;
   padding: 14px;
-  background: #ffffff;
+  background: var(--surface-color);
   color: var(--text-main);
   border: 1px solid var(--border-subtle);
   border-radius: 14px;
@@ -256,8 +256,23 @@
 }
 
 .google-btn {
-  background: #ffffff;
+  background: var(--surface-color);
   border-color: rgba(99, 102, 241, 0.2);
+}
+
+body.theme-dark .auth-container {
+  background:
+    radial-gradient(1100px 700px at 12% 20%, rgba(59, 130, 246, 0.18), transparent 60%),
+    radial-gradient(900px 600px at 88% 12%, rgba(14, 165, 233, 0.2), transparent 55%),
+    linear-gradient(135deg, #0b1120 0%, #111827 50%, #0b1120 100%);
+}
+
+body.theme-dark .auth-container::before {
+  opacity: 0.2;
+}
+
+body.theme-dark .auth-container::after {
+  opacity: 0.2;
 }
 
 .google-btn:hover {

--- a/frontend/src/components/Homepage.css
+++ b/frontend/src/components/Homepage.css
@@ -50,6 +50,12 @@ h1, h2, h3, button {
   border-bottom: 1px solid transparent; transition: all 0.3s ease;
 }
 .ww-header.scrolled { border-bottom: 1px solid var(--border-light); background: rgba(255, 255, 255, 0.95); }
+body.theme-dark .ww-header {
+  background: rgba(15, 23, 42, 0.85);
+}
+body.theme-dark .ww-header.scrolled {
+  background: rgba(15, 23, 42, 0.95);
+}
 .ww-nav { height: 80px; display: flex; align-items: center; justify-content: space-between; }
 .ww-brand { display: flex; align-items: center; gap: 12px; cursor: pointer; }
 .ww-logo-icon {
@@ -65,7 +71,7 @@ h1, h2, h3, button {
 .ww-btn-link { background: none; border: none; font-weight: 600; cursor: pointer; color: var(--text-main); }
 .ww-btn-primary { background: var(--color-primary); color: white; }
 .ww-btn-primary:hover { background: #4338CA; transform: translateY(-1px); }
-.ww-btn-white { background: white; color: var(--color-primary); }
+.ww-btn-white { background: var(--bg-card); color: var(--color-primary); }
 .ww-btn-white:hover { background: #f8f9fa; }
 .ww-menu-toggle { display: none; }
 
@@ -92,7 +98,7 @@ h1, h2, h3, button {
 .ww-hero-ref-visual { position: relative; padding-left: 20px; }
 .ww-main-image-wrapper { position: relative; }
 .ww-main-img { width: 100%; height: 550px; border-radius: 32px; box-shadow: var(--shadow-md); }
-.ww-float-card { position: absolute; background: white; border-radius: 20px; box-shadow: var(--shadow-float); padding: 20px; animation: float 6s ease-in-out infinite; border: 1px solid rgba(255,255,255,0.8); }
+.ww-float-card { position: absolute; background: var(--bg-card); border-radius: 20px; box-shadow: var(--shadow-float); padding: 20px; animation: float 6s ease-in-out infinite; border: 1px solid var(--border-light); }
 .icon-card { top: 40px; left: -40px; width: 72px; height: 72px; display: grid; place-items: center; border-radius: 24px; }
 .graph-card { bottom: 50px; right: -50px; width: 240px; padding: 24px; animation-delay: 2s; }
 .ww-graph-header { font-size: 0.9rem; color: var(--text-muted); margin-bottom: 6px; font-weight: 500; }
@@ -129,7 +135,7 @@ h1, h2, h3, button {
 .ww-center-icon { width: 56px; height: 56px; background: #111827; border-radius: 50%; display: flex; align-items: center; justify-content: center; box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1); position: relative; z-index: 2; }
 .ww-center-pulse { position: absolute; width: 100%; height: 100%; background: rgba(17, 24, 39, 0.1); border-radius: 50%; z-index: 1; animation: pulse-ring 2s cubic-bezier(0.215, 0.61, 0.355, 1) infinite; }
 @keyframes pulse-ring { 0% { transform: scale(1); opacity: 0.8; } 100% { transform: scale(1.5); opacity: 0; } }
-.ww-conn-card { position: absolute; background: white; padding: 12px 20px; border-radius: 12px; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 10px 15px -3px rgba(0, 0, 0, 0.05); display: flex; align-items: center; gap: 12px; font-weight: 600; color: #1F2937; border: 1px solid #F3F4F6; z-index: 5; white-space: nowrap; }
+.ww-conn-card { position: absolute; background: var(--bg-card); padding: 12px 20px; border-radius: 12px; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 10px 15px -3px rgba(0, 0, 0, 0.05); display: flex; align-items: center; gap: 12px; font-weight: 600; color: var(--text-main); border: 1px solid var(--border-light); z-index: 5; white-space: nowrap; }
 .icon-box { width: 32px; height: 32px; border-radius: 8px; display: flex; align-items: center; justify-content: center; }
 .ib-blue { background: #EFF6FF; color: #3B82F6; }
 .ib-green { background: #ECFDF5; color: #10B981; }
@@ -146,7 +152,7 @@ h1, h2, h3, button {
 }
 
 .ww-bento-card {
-  background: white;
+  background: var(--bg-card);
   border: 1px solid var(--border-light);
   border-radius: 20px;
   padding: 30px;
@@ -228,7 +234,7 @@ h1, h2, h3, button {
 .ww-cta-box p { font-size: 1.2rem; opacity: 0.9; margin-bottom: 32px; max-width: 600px; margin-left: auto; margin-right: auto; }
 
 /* --- Footer --- */
-.ww-footer { padding: 60px 0; border-top: 1px solid var(--border-light); background: white; }
+.ww-footer { padding: 60px 0; border-top: 1px solid var(--border-light); background: var(--bg-card); }
 .ww-footer-content { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 20px; }
 .ww-brand-footer { display: flex; align-items: center; gap: 8px; font-weight: 700; color: var(--text-main); }
 .ww-footer-links { display: flex; gap: 32px; }

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,41 +1,52 @@
 import React from 'react'
-import { Wallet } from 'lucide-react';
+import { Moon, Sun, Wallet } from 'lucide-react';
+import { useTheme } from '../context/ThemeContext';
 
 const Navbar = ({ isMenuOpen, setIsMenuOpen, smoothScroll, navigate }) => {
+    const { isDark, toggleTheme } = useTheme();
     return (
-        <header className="fixed top-0 left-0 w-full z-50 backdrop-blur-md bg-white/80 border-b border-zinc-200">
+        <header className="fixed top-0 left-0 w-full z-50 backdrop-blur-md bg-white/80 dark:bg-slate-900/80 border-b border-zinc-200 dark:border-slate-700">
             <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
 
                 {/* Logo */}
                 <button
                     onClick={() => smoothScroll("top")}
-                    className="flex items-center gap-2 font-bold text-xl text-zinc-900"
+                    className="flex items-center gap-2 font-bold text-xl text-zinc-900 dark:text-slate-100"
                 >
-                    <Wallet size={24} className="text-black" />
+                    <Wallet size={24} className="text-black dark:text-slate-100" />
                     WalletWise
                 </button>
 
                 {/* Desktop Nav */}
-                <nav className="hidden md:flex items-center gap-8">
+                <nav className="hidden md:flex items-center gap-6">
                     <button
                         onClick={() => smoothScroll("about")}
-                        className="text-zinc-600 hover:text-black transition"
+                        className="text-zinc-600 dark:text-slate-300 hover:text-black dark:hover:text-white transition"
                     >
                         About
                     </button>
 
                     <button
                         onClick={() => smoothScroll("features")}
-                        className="text-zinc-600 hover:text-black transition"
+                        className="text-zinc-600 dark:text-slate-300 hover:text-black dark:hover:text-white transition"
                     >
                         Features
                     </button>
 
                     <button
                         onClick={() => navigate("/signup")}
-                        className="px-5 py-2 rounded-full bg-black text-white hover:bg-zinc-800 transition"
+                        className="px-5 py-2 rounded-full bg-zinc-900 text-white hover:bg-zinc-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white transition"
                     >
                         Get Started
+                    </button>
+
+                    <button
+                        onClick={toggleTheme}
+                        aria-label={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+                        className="inline-flex items-center justify-center w-10 h-10 rounded-full border border-zinc-200 dark:border-slate-600 text-zinc-700 dark:text-slate-200 bg-white/70 dark:bg-slate-800/70 hover:bg-zinc-100 dark:hover:bg-slate-700 transition"
+                        type="button"
+                    >
+                        {isDark ? <Sun size={18} /> : <Moon size={18} />}
                     </button>
                 </nav>
 
@@ -45,26 +56,40 @@ const Navbar = ({ isMenuOpen, setIsMenuOpen, smoothScroll, navigate }) => {
                     onClick={() => setIsMenuOpen(!isMenuOpen)}
                     aria-label="Toggle menu"
                 >
-                    <span className="w-6 h-[2px] bg-black" />
-                    <span className="w-6 h-[2px] bg-black" />
-                    <span className="w-6 h-[2px] bg-black" />
+                    <span className="w-6 h-[2px] bg-black dark:bg-slate-100" />
+                    <span className="w-6 h-[2px] bg-black dark:bg-slate-100" />
+                    <span className="w-6 h-[2px] bg-black dark:bg-slate-100" />
                 </button>
             </div>
 
             {/* Mobile Menu */}
             {isMenuOpen && (
-                <div className="md:hidden bg-white border-t border-zinc-200 px-4 py-4 space-y-4">
-                    <button onClick={() => smoothScroll("about")} className="block w-full text-left">
+                <div className="md:hidden bg-white dark:bg-slate-900 border-t border-zinc-200 dark:border-slate-700 px-4 py-4 space-y-4">
+                    <button
+                        onClick={() => smoothScroll("about")}
+                        className="block w-full text-left text-zinc-700 dark:text-slate-200"
+                    >
                         About
                     </button>
-                    <button onClick={() => smoothScroll("features")} className="block w-full text-left">
+                    <button
+                        onClick={() => smoothScroll("features")}
+                        className="block w-full text-left text-zinc-700 dark:text-slate-200"
+                    >
                         Features
                     </button>
                     <button
                         onClick={() => navigate("/signup")}
-                        className="w-full py-2 rounded-lg bg-black text-white"
+                        className="w-full py-2 rounded-lg bg-zinc-900 text-white dark:bg-slate-100 dark:text-slate-900"
                     >
                         Get Started
+                    </button>
+                    <button
+                        onClick={toggleTheme}
+                        className="w-full flex items-center justify-center gap-2 py-2 rounded-lg border border-zinc-200 dark:border-slate-600 text-zinc-700 dark:text-slate-200 bg-white/80 dark:bg-slate-800/80"
+                        type="button"
+                    >
+                        {isDark ? <Sun size={16} /> : <Moon size={16} />}
+                        <span>{isDark ? 'Light mode' : 'Dark mode'}</span>
                     </button>
                 </div>
             )}

--- a/frontend/src/components/dashboard.css
+++ b/frontend/src/components/dashboard.css
@@ -771,14 +771,14 @@
   align-items: center;
   gap: 1.25rem;
   padding: 1.25rem;
-  background: #fcfdfe;
+  background: var(--bg-card);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
   transition: var(--transition-elegant);
 }
 
 .transaction-card:hover {
-  background: white;
+  background: var(--bg-card);
   border-color: var(--brand-primary);
   transform: translateX(5px);
 }
@@ -823,7 +823,7 @@
 }
 
 .goal-card {
-  background: white;
+  background: var(--bg-card);
   border-radius: var(--radius-lg);
   padding: 1.5rem;
   border: 1px solid var(--border-subtle);

--- a/frontend/src/context/ThemeContext.jsx
+++ b/frontend/src/context/ThemeContext.jsx
@@ -1,0 +1,55 @@
+import React, { createContext, useContext, useMemo, useState, useEffect } from 'react';
+
+const ThemeContext = createContext(null);
+const THEME_STORAGE_KEY = 'walletwise-theme';
+
+const getInitialTheme = () => {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+  if (stored === 'light' || stored === 'dark') {
+    return stored;
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(getInitialTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const body = document.body;
+
+    root.classList.toggle('dark', theme === 'dark');
+    root.style.colorScheme = theme;
+
+    body.classList.remove('theme-light', 'theme-dark');
+    body.classList.add(`theme-${theme}`);
+    body.setAttribute('data-theme', theme);
+
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  }, [theme]);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      isDark: theme === 'dark',
+      setTheme,
+      toggleTheme: () => setTheme((current) => (current === 'dark' ? 'light' : 'dark')),
+    }),
+    [theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return context;
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+    darkMode: "class",
     content: [
         "./src/**/*.{js,jsx,ts,tsx}",
         "./public/index.html"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "WalletWise",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Summary

Added a global theme provider with persistence and system preference support
Added light/dark toggle in both public and authenticated navs (desktop + mobile)
Applied theme-aware CSS variables and dark mode overrides across key surfaces
<img width="1919" height="957" alt="light-mode" src="https://github.com/user-attachments/assets/904ed3e9-b6d9-46e4-b7b3-b77863fb16d6" />
<img width="1919" height="948" alt="dark-mode" src="https://github.com/user-attachments/assets/d17bea41-0a1c-44e2-8ee3-cfb776c05783" />
