### PR TITLE
feat: add export financial reports (CSV & PDF) functionality

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "express": "^4.22.1",
         "express-rate-limit": "^8.2.1",
         "express-slow-down": "^3.0.1",
+        "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^7.8.8",
         "multer": "^2.0.2",
@@ -675,6 +676,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1015,6 +1017,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "express": "^4.22.1",
     "express-rate-limit": "^8.2.1",
     "express-slow-down": "^3.0.1",
+    "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^7.8.8",
     "multer": "^2.0.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,8 @@
         "axios": "^1.13.2",
         "chart.js": "^4.5.1",
         "framer-motion": "^12.27.5",
+        "jspdf": "^4.1.0",
+        "jspdf-autotable": "^5.0.7",
         "lucide-react": "^0.562.0",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.3.1",
@@ -3612,6 +3614,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -3635,6 +3643,13 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
@@ -5024,6 +5039,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -5365,6 +5390,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -5931,6 +5976,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.4"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-loader": {
@@ -6633,6 +6688,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -7823,6 +7888,17 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -7868,6 +7944,12 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -8873,6 +8955,20 @@
         }
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -9148,6 +9244,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/ipaddr.js": {
       "version": "2.3.0",
@@ -10898,6 +11000,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jspdf": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.1.0.tgz",
+      "integrity": "sha512-xd1d/XRkwqnsq6FP3zH1Q+Ejqn2ULIJeDZ+FTKpaabVpZREjsJKRJwuokTNgdqOU+fl55KgbvgZ1pRTSWCP2kQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.7.tgz",
+      "integrity": "sha512-2wr7H6liNDBYNwt25hMQwXkEWFOEopgKIvR1Eukuw6Zmprm/ZcnmLTQEjW7Xx3FCbD3v7pflLcnMAv/h1jFDQw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jspdf": "^2 || ^3 || ^4"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -11811,6 +11940,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -14227,6 +14362,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -15019,6 +15164,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -15381,6 +15536,16 @@
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "license": "MIT"
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/svgo": {
       "version": "1.3.2",
@@ -15775,6 +15940,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -16340,6 +16515,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,8 @@
     "axios": "^1.13.2",
     "chart.js": "^4.5.1",
     "framer-motion": "^12.27.5",
+    "jspdf": "^4.1.0",
+    "jspdf-autotable": "^5.0.7",
     "lucide-react": "^0.562.0",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.3.1",

--- a/frontend/src/pages/Reports.css
+++ b/frontend/src/pages/Reports.css
@@ -22,6 +22,7 @@
   letter-spacing: -0.02em;
   margin: 0.5rem 0;
   background: linear-gradient(to right, var(--brand-primary), var(--brand-secondary));
+  background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
@@ -378,9 +379,72 @@
 }
 
 @media (max-width: 640px) {
-  .reports-header,
-  .tabs-bar,
   .tabs-panels {
     width: 95%;
   }
+}
+
+/* Reports Actions Bar */
+.reports-actions-bar {
+  width: 92%;
+  max-width: 1200px;
+  margin: 0 auto 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.download-menu-container {
+  position: relative;
+  display: inline-block;
+}
+
+.download-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+  background-color: var(--brand-primary, #2563eb);
+  color: white;
+  border: none;
+  border-radius: var(--radius-lg, 0.5rem);
+  transition: background-color 0.2s;
+}
+
+.download-btn:hover {
+  background-color: var(--brand-secondary, #1d4ed8);
+}
+
+.download-dropdown {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  margin-top: 0.5rem;
+  background: var(--bg-card, #ffffff);
+  border: 1px solid var(--border-subtle, #e2e8f0);
+  border-radius: var(--radius-lg, 0.5rem);
+  box-shadow: var(--shadow-md, 0 4px 6px -1px rgba(0, 0, 0, 0.1));
+  z-index: 50;
+  min-width: 180px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.download-dropdown button {
+  text-align: left;
+  padding: 0.75rem 1rem;
+  background: none;
+  border: none;
+  color: var(--text-main, #1e293b);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  width: 100%;
+}
+
+.download-dropdown button:hover {
+  background-color: var(--bg-app, #f8fafc);
+  color: var(--brand-primary, #2563eb);
 }

--- a/frontend/src/pages/Reports.jsx
+++ b/frontend/src/pages/Reports.jsx
@@ -1,6 +1,9 @@
 import React, { useMemo, useRef, useState, useEffect, useCallback } from 'react';
 import { Pie, Bar, Line } from 'react-chartjs-2';
 import { Link } from 'react-router-dom';
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import { FaDownload } from 'react-icons/fa';
 
 import {
   Chart as ChartJS,
@@ -39,7 +42,10 @@ const Reports = () => {
     trends: [],
     insights: [],
     topPlaces: [],
-    dailySpend: []
+    insights: [],
+    topPlaces: [],
+    dailySpend: [],
+    transactions: []
   });
 
   const formatCurrency = (amount) =>
@@ -216,7 +222,9 @@ const Reports = () => {
         trends,
         insights,
         topPlaces,
-        dailySpend
+        topPlaces,
+        dailySpend,
+        transactions: monthExpenses
       });
     } catch (err) {
       console.error('Reports fetch error:', err);
@@ -412,6 +420,94 @@ const Reports = () => {
       ? 'Loading latest insights...'
       : 'Quick, student-friendly views of where your money went.';
 
+  const [downloadMenuOpen, setDownloadMenuOpen] = useState(false);
+
+  const handleExportCSV = () => {
+    if (!reportData.transactions || reportData.transactions.length === 0) {
+      alert('No transactions to export for this month.');
+      return;
+    }
+
+    const headers = ['Date', 'Category', 'Description', 'Amount'];
+    const rows = reportData.transactions.map(t => [
+      new Date(t.date).toLocaleDateString(),
+      t.category || 'Other',
+      t.description || '',
+      t.amount
+    ]);
+
+    let csvContent = "data:text/csv;charset=utf-8,"
+      + headers.join(",") + "\n"
+      + rows.map(e => e.join(",")).join("\n");
+
+    const encodedUri = encodeURI(csvContent);
+    const link = document.createElement("a");
+    link.setAttribute("href", encodedUri);
+    link.setAttribute("download", `monthly_report_${new Date().getMonth() + 1}_${new Date().getFullYear()}.csv`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    setDownloadMenuOpen(false);
+  };
+
+  const handleExportPDF = () => {
+    const doc = new jsPDF();
+    doc.setFontSize(18);
+    doc.text(`Financial Report - ${new Date().toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}`, 14, 22);
+
+    doc.setFontSize(12);
+    doc.text(`Total Spent: ${formatCurrency(reportData.monthTotal)}`, 14, 32);
+
+    // Summary Table
+    const summaryData = [
+      ['Metric', 'Value'],
+      ['Total Spent', formatCurrency(reportData.monthTotal)],
+      ['Budget Used', `${totalPercent}%`],
+      ['Top Category', reportData.pieCategories[0]?.label || 'N/A']
+    ];
+
+    autoTable(doc, {
+      startY: 40,
+      head: [summaryData[0]],
+      body: summaryData.slice(1),
+      theme: 'grid',
+      headStyles: { fillColor: [37, 99, 235] }
+    });
+
+    // Category Breakdown
+    doc.text('Category Breakdown', 14, doc.lastAutoTable.finalY + 14);
+
+    const categoryData = reportData.pieCategories.map(c => [c.label, `${c.value}%`, formatCurrency(c.amount)]);
+
+    autoTable(doc, {
+      startY: doc.lastAutoTable.finalY + 20,
+      head: [['Category', 'Percentage', 'Amount']],
+      body: categoryData,
+      theme: 'striped',
+      headStyles: { fillColor: [37, 99, 235] }
+    });
+
+    // Transactions List
+    doc.text('Transaction Details', 14, doc.lastAutoTable.finalY + 14);
+
+    const txRows = reportData.transactions.map(t => [
+      new Date(t.date).toLocaleDateString(),
+      t.category || 'Other',
+      t.description || '',
+      formatCurrency(t.amount)
+    ]);
+
+    autoTable(doc, {
+      startY: doc.lastAutoTable.finalY + 20,
+      head: [['Date', 'Category', 'Description', 'Amount']],
+      body: txRows,
+      theme: 'striped'
+    });
+
+    doc.save(`monthly_report_${new Date().getMonth() + 1}_${new Date().getFullYear()}.pdf`);
+    setDownloadMenuOpen(false);
+  };
+
   return (
     <div className="reports-page">
       <header className="reports-header">
@@ -427,6 +523,22 @@ const Reports = () => {
           <p>{headerNote}</p>
         </div>
       </header>
+      <div className="reports-actions-bar">
+        <div className="download-menu-container">
+          <button
+            className="download-btn primary-button"
+            onClick={() => setDownloadMenuOpen(!downloadMenuOpen)}
+          >
+            <FaDownload /> Download Report
+          </button>
+          {downloadMenuOpen && (
+            <div className="download-dropdown">
+              <button onClick={handleExportCSV}>Export as CSV</button>
+              <button onClick={handleExportPDF}>Export as PDF</button>
+            </div>
+          )}
+        </div>
+      </div>
 
       {(loading || error) && (
         <div className={`reports-status ${error ? 'error' : 'loading'}`}>

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -202,7 +202,6 @@
   transition: all 0.2s ease;
 }
 
-/* Specific Dark Mode Overrides */
 body.theme-dark .form-group input,
 body.theme-dark .form-group select {
   background-color: var(--bg-card);
@@ -219,7 +218,7 @@ body.theme-dark .form-group select {
   color: var(--text-main);
 }
 
-/* Autofill Fix for Dark Mode */
+
 .form-group input:-webkit-autofill,
 .form-group input:-webkit-autofill:hover,
 .form-group input:-webkit-autofill:focus,


### PR DESCRIPTION
### Overview
Implemented export functionality on the Reports / Insights page, allowing users to download their financial data in CSV and PDF formats.

### ✅ What’s Added

- Download Report button added to Reports page
- Export options:
  - CSV format
  - PDF format
- CSV export includes:
  - Transaction list (date, category, amount, note)
  - Monthly totals
  - Category-wise breakdown
- PDF export includes:
  - Total spending summary
  - Selected month/date range

###  Purpose

This feature improves usability by enabling users to:
- Save financial reports for personal records
- Share summaries with parents/guardians
- Use financial data for budgeting or submissions
- Maintain portable financial documentation

### Impact

- Enhances platform professionalism
- Adds real-world financial tool capability
- Improves user trust and product maturity
- Increases overall feature completeness

solve #103 
---

Export functionality is fully integrated with existing Reports data and maintains UI consistency.
<img width="1919" height="918" alt="image" src="https://github.com/user-attachments/assets/5011cce0-6328-4c55-bd49-190635e42aec" />
[monthly_report_2_2026 (3).pdf](https://github.com/user-attachments/files/25284648/monthly_report_2_2026.3.pdf)
[monthly_report_2_2026 (2).pdf](https://github.com/user-attachments/files/25284653/monthly_report_2_2026.2.pdf)
[monthly_report_2_2026 (1).csv](https://github.com/user-attachments/files/25284654/monthly_report_2_2026.1.csv)
