### PR TITLE
Fix: Enable trust proxy for correct rate limiting (#136)

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -14,6 +14,9 @@ dotenv.config();
 // Initialize Express app
 const app = express();
 
+// Enable trust proxy for correct rate limiting behind load balancers (Vercel, Heroku, AWS ELB)
+app.set('trust proxy', 1);
+
 // ==================== SECURITY HEADERS ====================
 app.use(helmet());
 


### PR DESCRIPTION
## Description
This pull request addresses the critical vulnerability identified in issue #136 where the application lacked the `trust proxy` setting. When deployed behind a reverse proxy or load balancer (like on Vercel, Heroku, or AWS), Express by default sees all requests coming from the proxy's IP address. This causes the rate limiter to ban the proxy's IP, effectively causing a Denial of Service for all users.

By setting `app.set('trust proxy', 1)`, Express is instructed to trust the first proxy hop and correctly identify the client's original IP address from the `X-Forwarded-For` header.

## Changes Implemented
- [x] **Server Configuration**: Updated `backend/server.js` to include `app.set('trust proxy', 1);` before initializing security middleware.

## Refrence #136