### PR TITLE
Fix: Configure Multer limits and file filter

### DIFF
--- a/backend/middleware/multer.js
+++ b/backend/middleware/multer.js
@@ -2,6 +2,18 @@ const multer = require('multer');
 
 const storage = multer.memoryStorage();
 
-const singleUpload = multer({ storage }).single('file');
+const singleUpload = multer({
+    storage,
+    limits: {
+        fileSize: 2 * 1024 * 1024 // Limit to 2MB
+    },
+    fileFilter: (req, file, cb) => {
+        if (file.mimetype.startsWith('image/')) {
+            cb(null, true);
+        } else {
+            cb(new Error('Only images are allowed'), false);
+        }
+    }
+}).single('file');
 
 module.exports = singleUpload;


### PR DESCRIPTION

## Description
The application was using `multer` with `memoryStorage` but failed to define any `limits`. This meant that an attacker could upload a single extremely large file (e.g., 2GB), which `multer` would attempt to buffer entirely into RAM, causing the Node.js process to crash with an Out-of-Memory (OOM) error.

This PR introduces stric configuration to `backend/middleware/multer.js` to prevent this attack vector.

## Changes Implemented
- [x] **File Size Limit**: Configured `limits: { fileSize: 2 * 1024 * 1024 }` (2MB).
- [x] **File Type Filter**: Added a `fileFilter` to accept only `image/*` mime types.
- [x] **Error Handling**: Rejects non-image files with a clear error message.

## How to Test
1. **Pull this branch:** `git checkout fix/file-upload-dos`
2. **Start the server:** `npm start`
3. **Verify:**
   - Attempt to upload an image smaller than 2MB -> **Success**.
   - Attempt to upload a file larger than 2MB -> **Error (File too large)**.
   - Attempt to upload a non-image file (e.g., .txt, .exe) -> **Error (Only images are allowed)**.

## Checklist
- [x] Server starts without errors.
- [x] Mitigates OOM DoS vector.

## Reference  #144