### PR TITLE
Fix: Enable state parameter for Google OAuth (Login CSRF)

### DIFF
--- a/backend/routes/oauthRoutes.js
+++ b/backend/routes/oauthRoutes.js
@@ -5,7 +5,11 @@ const authController = require('../controllers/authController');
 
 const router = express.Router();
 
-router.get('/google', passport.authenticate('google', { scope: ['profile', 'email'], session: false }));
+router.get('/google', passport.authenticate('google', {
+  scope: ['profile', 'email'],
+  session: false,
+  state: true
+}));
 
 router.get(
   '/google/callback',


### PR DESCRIPTION
# PR: Fix OAuth Login CSRF

## Description
This PR addresses **Issue #154: OAuth Login CSRF**.
The previous Google OAuth implementation did not use the `state` parameter, making it vulnerable to Login CSRF attacks where an attacker could link their Google account to a victim's session.

### Changes
Enabled `state: true` in `backend/routes/oauthRoutes.js` for the Google Passport strategy.

```javascript
router.get('/google', passport.authenticate('google', { 
  scope: ['profile', 'email'], 
  session: false,
  state: true // <--- ENFORCED
}));