### PR TITLE
fix(#216): debounce transaction search field with 300ms delay

### DIFF
--- a/frontend/src/hooks/useDebounce.js
+++ b/frontend/src/hooks/useDebounce.js
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * useDebounce - Returns a debounced copy of the value.
+ * The debounced value only updates after the specified delay (ms) has passed
+ * without the value changing. Clears the timer on component unmount to prevent
+ * memory leaks.
+ *
+ * @param {*} value - The value to debounce
+ * @param {number} delay - Delay in milliseconds (default: 300)
+ * @returns {*} The debounced value
+ */
+const useDebounce = (value, delay = 300) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    // Instantly clear debounce when the value is empty (better UX: instant reset)
+    if (value === '' || value === null || value === undefined) {
+      setDebouncedValue(value);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    // Cleanup: cancel previous timer on value change or unmount
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
+import useDebounce from '../hooks/useDebounce';
 import { Link, useNavigate } from 'react-router-dom';
 import api from '../api/client';
 import { FaFilter, FaSearch } from 'react-icons/fa';
@@ -63,6 +64,9 @@ const Transactions = () => {
 
   // Filter State
   const [searchTerm, setSearchTerm] = useState('');
+  // Debounced search — only triggers API call after 300ms of inactivity
+  // Empty string is instantly applied (no debounce on clear for better UX)
+  const debouncedSearch = useDebounce(searchTerm, 300);
   const [activeQuickFilter, setActiveQuickFilter] = useState('all');
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [startDate, setStartDate] = useState('');
@@ -77,7 +81,7 @@ const Transactions = () => {
         page: currentPage,
         limit,
         sort: sortMode,
-        search: searchTerm,
+        search: debouncedSearch,
       };
 
       if (activeQuickFilter !== 'all') {
@@ -119,15 +123,16 @@ const Transactions = () => {
     } finally {
       setLoading(false);
     }
-  }, [currentPage, limit, sortMode, searchTerm, activeQuickFilter, startDate, endDate, navigate]);
+  }, [currentPage, limit, sortMode, debouncedSearch, activeQuickFilter, startDate, endDate, navigate]);
 
   useEffect(() => {
     fetchTransactions();
   }, [fetchTransactions]);
 
+  // Reset to page 1 when debounced search or filters change
   useEffect(() => {
     setCurrentPage(1);
-  }, [searchTerm, activeQuickFilter, sortMode, startDate, endDate]);
+  }, [debouncedSearch, activeQuickFilter, sortMode, startDate, endDate]);
 
 
   const formatCurrency = (amount) =>


### PR DESCRIPTION
This pull request introduces a debounced search feature to the `Transactions` page, improving user experience and performance by reducing unnecessary API calls as users type in the search box. The main change is the addition and integration of a new custom hook, `useDebounce`, which delays the API call until the user has stopped typing for a short period.

**Debounced search functionality:**

* Added a new custom hook `useDebounce` in `frontend/src/hooks/useDebounce.js` to provide a debounced value for any input, with instant reset when the input is cleared.
* Integrated `useDebounce` into the `Transactions` page to debounce the `searchTerm` state, so API calls are only triggered after 300ms of inactivity. [[1]](diffhunk://#diff-f81f9cb644346eb445de68bec09d6a1d218fc520dd29d9b8535460c276c2ae92R2) [[2]](diffhunk://#diff-f81f9cb644346eb445de68bec09d6a1d218fc520dd29d9b8535460c276c2ae92R67-R69)
* Updated all API calls in `Transactions.jsx` to use the debounced search value instead of the raw search input, reducing redundant requests as the user types. [[1]](diffhunk://#diff-f81f9cb644346eb445de68bec09d6a1d218fc520dd29d9b8535460c276c2ae92L80-R84) [[2]](diffhunk://#diff-f81f9cb644346eb445de68bec09d6a1d218fc520dd29d9b8535460c276c2ae92L122-R135)
* Adjusted effect dependencies and pagination reset logic to work with the debounced search value, ensuring correct UI updates and improved UX.- Add custom useDebounce hook (frontend/src/hooks/useDebounce.js)
- Hook supports instant reset on empty string (better UX: no debounce on clear)
- Update Transactions.jsx to use debouncedSearch instead of raw searchTerm for API calls, prevents excessive requests on rapid keystrokes
- Update useCallback and page-reset useEffect to depend on debouncedSearch

Closes #216