### PR TITLE
feature: implement recurring transaction skip next action

### DIFF
--- a/backend/routes/transactionRoutes.js
+++ b/backend/routes/transactionRoutes.js
@@ -13,6 +13,9 @@ router.get('/', protect, transactionController.getAllTransactions);
 // Undo transaction ✅ IMPORTANT
 router.post('/:id/undo', protect, transactionController.undoTransaction);
 
+// Skip next occurrence
+router.post('/:id/skip', protect, transactionController.skipNextOccurrence);
+
 // Update transaction
 router.put('/:id', protect, transactionController.updateTransaction);
 


### PR DESCRIPTION
This pull request introduces a new feature for handling recurring transactions, allowing users to skip the next scheduled occurrence of a transaction. It also ensures that recurring transactions have their `nextExecutionDate` properly set and exposes the new functionality via the API.

**Recurring transaction enhancements:**

* Added a new controller method `skipNextOccurrence` in `transactionController.js` to allow users to skip the next occurrence of a recurring transaction by updating its `nextExecutionDate` based on the interval (`daily`, `weekly`, or `monthly`).
* Modified transaction creation logic to set `transaction.nextExecutionDate` for recurring transactions, ensuring this field is always populated when applicable.

**API changes:**

* Registered a new route in `transactionRoutes.js` for skipping the next occurrence of a transaction (`POST /:id/skip`).
* Exported the new `skipNextOccurrence` controller method in the module exports of `transactionController.js`.