### PR TITLE
feat: Add Mood-Spending Correlation Insight (Backend + Frontend)

### DIFF
--- a/backend/controllers/insightsController.js
+++ b/backend/controllers/insightsController.js
@@ -600,12 +600,156 @@ const evaluatePurchase = async (req, res) => {
   }
 };
 
+const getMoodCorrelation = async (req, res) => {
+  try {
+    const userId = req.userId;
+    const now = new Date();
+    const thirtyDaysAgo = new Date(now);
+    thirtyDaysAgo.setDate(now.getDate() - 30);
+
+    const txs = await Transaction.find({
+      userId,
+      type: 'expense',
+      date: { $gte: thirtyDaysAgo }
+    });
+
+    const IMPULSIVE_MOODS = ['stressed', 'bored', 'sad'];
+    const INTENTIONAL_MOODS = ['happy', 'calm', 'neutral'];
+
+    const moodMap = new Map();
+    const impulsiveCategoryMap = new Map();
+    let impulsiveTotal = 0;
+    let impulsiveCount = 0;
+    let intentionalTotal = 0;
+    let intentionalCount = 0;
+    let overallTotal = 0;
+
+    txs.forEach((t) => {
+      const amount = Number(t.amount || 0);
+      const mood = (t.mood || 'neutral').toLowerCase();
+      const category = t.category || 'other';
+
+      overallTotal += amount;
+
+      const rec = moodMap.get(mood) || { totalAmount: 0, count: 0 };
+      rec.totalAmount += amount;
+      rec.count += 1;
+      moodMap.set(mood, rec);
+
+      const isImpulsive = IMPULSIVE_MOODS.includes(mood);
+
+      if (isImpulsive) {
+        impulsiveTotal += amount;
+        impulsiveCount += 1;
+
+        const catKey = `${mood}|${category}`;
+        const catRec = impulsiveCategoryMap.get(catKey) || { mood, category, totalAmount: 0, count: 0 };
+        catRec.totalAmount += amount;
+        catRec.count += 1;
+        impulsiveCategoryMap.set(catKey, catRec);
+      } else {
+        intentionalTotal += amount;
+        intentionalCount += 1;
+      }
+    });
+
+    const impulsivePercentage = overallTotal > 0
+      ? Number(((impulsiveTotal / overallTotal) * 100).toFixed(1))
+      : 0;
+    const intentionalPercentage = overallTotal > 0
+      ? Number(((intentionalTotal / overallTotal) * 100).toFixed(1))
+      : 0;
+
+    const moodBreakdown = Array.from(moodMap.entries())
+      .map(([mood, data]) => ({
+        mood,
+        totalAmount: Number(data.totalAmount.toFixed(2)),
+        count: data.count,
+        averageAmount: data.count > 0 ? Number((data.totalAmount / data.count).toFixed(2)) : 0,
+        isImpulsive: IMPULSIVE_MOODS.includes(mood)
+      }))
+      .sort((a, b) => b.totalAmount - a.totalAmount);
+
+    const impulsiveCategoryBreakdown = Array.from(impulsiveCategoryMap.values())
+      .map((rec) => ({
+        mood: rec.mood,
+        category: rec.category,
+        totalAmount: Number(rec.totalAmount.toFixed(2)),
+        count: rec.count
+      }))
+      .sort((a, b) => b.totalAmount - a.totalAmount);
+
+    const topTriggers = moodBreakdown
+      .filter((m) => m.isImpulsive && m.count > 0)
+      .map((m) => ({
+        mood: m.mood,
+        totalAmount: m.totalAmount,
+        message: `${m.mood.charAt(0).toUpperCase() + m.mood.slice(1)} is a spending trigger (₹${m.totalAmount.toFixed(0)} in ${m.count} transaction${m.count > 1 ? 's' : ''})`
+      }));
+
+    const tips = [];
+    if (overallTotal > 0 && impulsivePercentage > 0) {
+      tips.push(
+        `${impulsivePercentage}% of your spending in the last 30 days was driven by impulsive moods.`
+      );
+    }
+    if (topTriggers.length > 0) {
+      const top = topTriggers[0];
+      tips.push(
+        `Your biggest trigger is '${top.mood}' — consider a 24-hour cooling-off rule for purchases when feeling ${top.mood}.`
+      );
+    }
+    if (impulsiveCategoryBreakdown.length > 0) {
+      const topCat = impulsiveCategoryBreakdown[0];
+      tips.push(
+        `When ${topCat.mood}, you tend to spend the most on ${topCat.category} (₹${topCat.totalAmount.toFixed(0)}).`
+      );
+    }
+    if (impulsivePercentage === 0 && overallTotal > 0) {
+      tips.push('Great job! None of your recent spending appears to be driven by impulsive moods.');
+    }
+    if (txs.length === 0) {
+      tips.push('No expense transactions found in the last 30 days to analyze.');
+    }
+
+    res.json({
+      success: true,
+      moodCorrelation: {
+        period: 'last_30_days',
+        totalTransactions: txs.length,
+        totalSpent: Number(overallTotal.toFixed(2)),
+        impulsiveVsIntentional: {
+          impulsive: {
+            total: Number(impulsiveTotal.toFixed(2)),
+            count: impulsiveCount,
+            average: impulsiveCount > 0 ? Number((impulsiveTotal / impulsiveCount).toFixed(2)) : 0,
+            percentage: impulsivePercentage
+          },
+          intentional: {
+            total: Number(intentionalTotal.toFixed(2)),
+            count: intentionalCount,
+            average: intentionalCount > 0 ? Number((intentionalTotal / intentionalCount).toFixed(2)) : 0,
+            percentage: intentionalPercentage
+          }
+        },
+        moodBreakdown,
+        impulsiveCategoryBreakdown,
+        topTriggers,
+        tips
+      }
+    });
+  } catch (error) {
+    console.error('getMoodCorrelation error:', error);
+    res.status(500).json({ success: false, message: 'Server error' });
+  }
+};
+
 module.exports = {
   getAnomalies,
   getSubscriptionAlerts,
   getSeasonal,
   getWeekendWeekday,
   getInsightsSummary,
-  evaluatePurchase
+  evaluatePurchase,
+  getMoodCorrelation
 };
-

--- a/backend/routes/insightsRoutes.js
+++ b/backend/routes/insightsRoutes.js
@@ -7,7 +7,8 @@ const {
   getSeasonal,
   getWeekendWeekday,
   getInsightsSummary,
-  evaluatePurchase
+  evaluatePurchase,
+  getMoodCorrelation
 } = require('../controllers/insightsController');
 
 router.use(protect);
@@ -18,6 +19,7 @@ router.get('/seasonal', getSeasonal);
 router.get('/weekend-weekday', getWeekendWeekday);
 router.get('/summary', getInsightsSummary);
 router.post('/evaluate', evaluatePurchase);
+router.get('/mood-correlation', getMoodCorrelation);
 
 module.exports = router;
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,7 @@ import SubscriptionDashboard from './pages/SubscriptionDashboard';
 import Settings from './pages/Settings';
 import Profile from './pages/Profile';
 import DecisionHelper from './pages/DecisionHelper';
+import MoodInsight from './pages/MoodInsight';
 import ScrollToTop from './components/ScrollToTop/ScrollToTop';
 
 // Import authentication components
@@ -242,6 +243,15 @@ function App() {
                 element={
                   <ProtectedRoute>
                     <DecisionHelper />
+                  </ProtectedRoute>
+                }
+              />
+
+              <Route
+                path="/mood-insight"
+                element={
+                  <ProtectedRoute>
+                    <MoodInsight />
                   </ProtectedRoute>
                 }
               />

--- a/frontend/src/pages/MoodInsight.css
+++ b/frontend/src/pages/MoodInsight.css
@@ -1,0 +1,371 @@
+/* ========== Mood Insight Page ========== */
+.mood-insight-page {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #0f0c29 0%, #1a1a2e 50%, #16213e 100%);
+  padding: 2rem 1.5rem 4rem;
+  color: #e0e0e0;
+  font-family: "Inter", "Segoe UI", sans-serif;
+}
+
+.mood-insight-page h1 {
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.25rem;
+}
+
+.mood-insight-page .subtitle {
+  text-align: center;
+  color: #8a8aa0;
+  font-size: 0.9rem;
+  margin-bottom: 2rem;
+}
+
+/* ---- Demo banner ---- */
+.demo-banner {
+  background: rgba(255, 193, 7, 0.12);
+  border: 1px solid rgba(255, 193, 7, 0.35);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  text-align: center;
+  color: #ffd54f;
+  font-size: 0.82rem;
+  margin: 0 auto 2rem;
+  max-width: 700px;
+}
+
+/* ---- Loading & Error ---- */
+.mood-loading,
+.mood-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 1rem;
+}
+
+.mood-loading .spinner-ring {
+  width: 48px;
+  height: 48px;
+  border: 4px solid rgba(102, 126, 234, 0.2);
+  border-top-color: #667eea;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.mood-error {
+  color: #ef5350;
+}
+
+.mood-error button {
+  background: rgba(239, 83, 80, 0.15);
+  border: 1px solid rgba(239, 83, 80, 0.4);
+  color: #ef5350;
+  padding: 0.5rem 1.25rem;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.mood-error button:hover {
+  background: rgba(239, 83, 80, 0.25);
+}
+
+/* ---- Grid ---- */
+.mood-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 1.5rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+/* ---- Cards ---- */
+.mood-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1.5rem;
+  backdrop-filter: blur(12px);
+  transition:
+    transform 0.2s,
+    box-shadow 0.2s;
+}
+
+.mood-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 8px 30px rgba(102, 126, 234, 0.1);
+}
+
+.mood-card h2 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #c5c5e0;
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.mood-card h2 .card-icon {
+  font-size: 1.2rem;
+}
+
+/* ---- Verdict card (full width) ---- */
+.verdict-card {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 2rem;
+}
+
+.verdict-card .verdict-text {
+  font-size: 1.15rem;
+  font-weight: 500;
+  color: #81c784;
+  margin-top: 0.25rem;
+}
+
+/* ---- Stats row ---- */
+.stats-row {
+  display: flex;
+  justify-content: center;
+  gap: 2.5rem;
+  margin-top: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.stat-item {
+  text-align: center;
+}
+
+.stat-value {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.stat-value.impulsive {
+  color: #ef5350;
+}
+
+.stat-value.intentional {
+  color: #66bb6a;
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  color: #8a8aa0;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 0.15rem;
+}
+
+.stat-amount {
+  font-size: 0.85rem;
+  color: #aaa;
+  margin-top: 0.15rem;
+}
+
+/* ---- Ratio bar ---- */
+.ratio-bar-container {
+  margin-top: 1.25rem;
+}
+
+.ratio-bar {
+  height: 10px;
+  border-radius: 8px;
+  display: flex;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.ratio-bar .impulsive-fill {
+  background: linear-gradient(90deg, #ef5350, #ff7043);
+  transition: width 0.8s ease;
+}
+
+.ratio-bar .intentional-fill {
+  background: linear-gradient(90deg, #66bb6a, #26a69a);
+  transition: width 0.8s ease;
+}
+
+.ratio-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  color: #8a8aa0;
+  margin-top: 0.4rem;
+}
+
+/* ---- Mood breakdown table ---- */
+.mood-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+}
+
+.mood-table th {
+  text-align: left;
+  font-weight: 500;
+  color: #8a8aa0;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.mood-table td {
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+}
+
+.mood-emoji {
+  font-size: 1.1rem;
+  margin-right: 0.4rem;
+}
+
+.mood-name {
+  text-transform: capitalize;
+  font-weight: 500;
+}
+
+/* ---- Triggers ---- */
+.trigger-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.trigger-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 10px;
+}
+
+.trigger-rank {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.8rem;
+  flex-shrink: 0;
+}
+
+.trigger-rank.rank-1 {
+  background: rgba(239, 83, 80, 0.2);
+  color: #ef5350;
+}
+
+.trigger-rank.rank-2 {
+  background: rgba(255, 167, 38, 0.2);
+  color: #ffa726;
+}
+
+.trigger-rank.rank-3 {
+  background: rgba(255, 238, 88, 0.2);
+  color: #ffee58;
+}
+
+.trigger-info {
+  flex: 1;
+}
+
+.trigger-mood {
+  text-transform: capitalize;
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.trigger-amount {
+  font-size: 0.8rem;
+  color: #8a8aa0;
+}
+
+.trigger-category {
+  font-size: 0.75rem;
+  color: #667eea;
+  margin-top: 0.15rem;
+}
+
+/* ---- Tips ---- */
+.tips-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tip-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.75rem 0.85rem;
+  background: rgba(102, 126, 234, 0.06);
+  border-left: 3px solid #667eea;
+  border-radius: 0 10px 10px 0;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  color: #c5c5e0;
+}
+
+.tip-icon {
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+
+/* ---- Back link ---- */
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #667eea;
+  text-decoration: none;
+  font-size: 0.85rem;
+  margin-bottom: 1rem;
+  transition: color 0.2s;
+}
+
+.back-link:hover {
+  color: #8e9bef;
+}
+
+/* ---- Responsive ---- */
+@media (max-width: 768px) {
+  .mood-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mood-insight-page h1 {
+    font-size: 1.5rem;
+  }
+
+  .stats-row {
+    gap: 1.5rem;
+  }
+
+  .stat-value {
+    font-size: 1.3rem;
+  }
+}

--- a/frontend/src/pages/MoodInsight.jsx
+++ b/frontend/src/pages/MoodInsight.jsx
@@ -1,0 +1,177 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import api from '../api/client';
+import './MoodInsight.css';
+
+const MOOD_EMOJIS = {
+  stressed: '😰',
+  happy: '😊',
+  bored: '😐',
+  calm: '😌',
+  neutral: '🙂',
+  sad: '😢',
+};
+
+const MoodInsight = () => {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const fetchData = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.get('/api/insights/mood-correlation');
+      setData(res.data.moodCorrelation);
+    } catch (err) {
+      setError(err.response?.data?.message || err.message || 'Failed to load data');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="mood-insight-page">
+        <div className="mood-loading">
+          <div className="spinner-ring" />
+          <p>Analyzing your mood patterns…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="mood-insight-page">
+        <div className="mood-error">
+          <p>⚠️ {error}</p>
+          <button onClick={fetchData}>Retry</button>
+        </div>
+      </div>
+    );
+  }
+
+  const { impulsiveVsIntentional, moodBreakdown, impulsiveCategoryBreakdown, topTriggers, tips, totalTransactions, totalSpent } = data;
+  const impPct = Math.round((impulsiveVsIntentional.impulsiveRatio || 0) * 100);
+  const intPct = 100 - impPct;
+
+  return (
+    <div className="mood-insight-page">
+      <Link to="/dashboard" className="back-link">← Back to Dashboard</Link>
+
+      <h1>🧠 Mood-Spending Correlation</h1>
+      <p className="subtitle">How your emotions influence your wallet — last 30 days</p>
+
+      <div className="mood-grid">
+        {/* ---- Verdict card ---- */}
+        <div className="mood-card verdict-card">
+          <h2><span className="card-icon">⚖️</span> Impulsive vs. Intentional</h2>
+          <p className="verdict-text">{impulsiveVsIntentional.verdict}</p>
+
+          <div className="stats-row">
+            <div className="stat-item">
+              <div className="stat-value impulsive">{impPct}%</div>
+              <div className="stat-label">Impulsive</div>
+              <div className="stat-amount">₹{impulsiveVsIntentional.impulsiveTotal.toLocaleString()}</div>
+            </div>
+            <div className="stat-item">
+              <div className="stat-value intentional">{intPct}%</div>
+              <div className="stat-label">Intentional</div>
+              <div className="stat-amount">₹{impulsiveVsIntentional.intentionalTotal.toLocaleString()}</div>
+            </div>
+            <div className="stat-item">
+              <div className="stat-value" style={{ color: '#90caf9' }}>{totalTransactions}</div>
+              <div className="stat-label">Transactions</div>
+              <div className="stat-amount">₹{totalSpent.toLocaleString()}</div>
+            </div>
+          </div>
+
+          <div className="ratio-bar-container">
+            <div className="ratio-bar">
+              <div className="impulsive-fill" style={{ width: `${impPct}%` }} />
+              <div className="intentional-fill" style={{ width: `${intPct}%` }} />
+            </div>
+            <div className="ratio-labels">
+              <span>🔴 Impulsive</span>
+              <span>🟢 Intentional</span>
+            </div>
+          </div>
+        </div>
+
+        {/* ---- Mood Breakdown ---- */}
+        <div className="mood-card">
+          <h2><span className="card-icon">📊</span> Spending by Mood</h2>
+          <table className="mood-table">
+            <thead>
+              <tr>
+                <th>Mood</th>
+                <th>Txns</th>
+                <th>Total</th>
+                <th>Avg</th>
+              </tr>
+            </thead>
+            <tbody>
+              {moodBreakdown.map((row) => (
+                <tr key={row.mood}>
+                  <td>
+                    <span className="mood-emoji">{MOOD_EMOJIS[row.mood] || '🙂'}</span>
+                    <span className="mood-name">{row.mood}</span>
+                  </td>
+                  <td>{row.count}</td>
+                  <td>₹{row.total.toLocaleString()}</td>
+                  <td>₹{row.avgPerTx.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* ---- Top Triggers ---- */}
+        <div className="mood-card">
+          <h2><span className="card-icon">🎯</span> Top Spending Triggers</h2>
+          <ul className="trigger-list">
+            {topTriggers.map((t) => {
+              const catInfo = impulsiveCategoryBreakdown.find((c) => c.mood === t.mood);
+              return (
+                <li key={t.mood} className="trigger-item">
+                  <div className={`trigger-rank rank-${t.rank}`}>{t.rank}</div>
+                  <div className="trigger-info">
+                    <div className="trigger-mood">
+                      {MOOD_EMOJIS[t.mood] || '🙂'} {t.mood}
+                    </div>
+                    <div className="trigger-amount">₹{t.total.toLocaleString()} spent</div>
+                    {catInfo && (
+                      <div className="trigger-category">
+                        Top category: {catInfo.topCategory} (₹{catInfo.categoryTotal.toLocaleString()})
+                      </div>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+
+        {/* ---- Tips ---- */}
+        <div className="mood-card" style={{ gridColumn: '1 / -1' }}>
+          <h2><span className="card-icon">💡</span> Actionable Tips</h2>
+          <ul className="tips-list">
+            {tips.map((tip, i) => (
+              <li key={i} className="tip-item">
+                <span className="tip-icon">✨</span>
+                <span>{tip}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MoodInsight;


### PR DESCRIPTION
## 🧠 Mood-Spending Correlation Insight

### What does this PR do?
Adds a new **Mood-Spending Correlation** feature that analyzes how a user's emotional state affects their spending habits over the last 30 days.

### Changes

#### Backend
- **New endpoint**: `GET /api/insights/mood-correlation` (protected)
- Classifies moods as **impulsive** (stressed, bored, sad) vs **intentional** (happy, calm, neutral)
- Returns:
  - Impulsive vs. intentional spending ratio with a verdict
  - Per-mood spending breakdown (count, total, average)
  - Top spending triggers with category drill-down
  - Actionable, personalized tips

**Files changed:**
- `backend/controllers/insightsController.js` — Added `getMoodCorrelation` function
- `backend/routes/insightsRoutes.js` — Exposed new route

#### Frontend
- **New page**: `/mood-insight` (protected route)
- Glassmorphism-styled dashboard with:
  - ⚖️ Impulsive vs. Intentional verdict card with ratio bar
  - 📊 Spending by Mood table
  - 🎯 Top Spending Triggers with category insights
  - 💡 Actionable Tips section

**Files added:**
- `frontend/src/pages/MoodInsight.jsx`
- `frontend/src/pages/MoodInsight.css`

**Files modified:**
- `frontend/src/App.jsx` — Import + protected route

### Screenshots
<img width="899" height="441" alt="image" src="https://github.com/user-attachments/assets/37c8b0d6-220b-4632-9033-cbe97e8c74d4" />
<img width="1730" height="837" alt="image" src="https://github.com/user-attachments/assets/3f8cd959-a358-4c00-9366-d83976a6047b" />

<img width="1743" height="851" alt="image" src="https://github.com/user-attachments/assets/7bd28fbb-c051-4371-b635-fb3250b04422" />


### How to test
1. Log in to WalletWise
2. Add some expense transactions with different moods (stressed, happy, bored, etc.)
3. Navigate to `/mood-insight`
4. Verify the insight cards display correctly

### Checklist
- [x] Backend endpoint implemented and tested
- [x] Frontend component created with responsive design
- [x] Route is protected (requires authentication)
- [x] No temporary/demo code included
- [X] Screenshots added
