### PR TITLE
fix: Add strict numeric validation to budget update to prevent negati…

### DIFF
--- a/backend/controllers/budgetController.js
+++ b/backend/controllers/budgetController.js
@@ -414,12 +414,40 @@ const updateBudget = async (req, res) => {
         }
 
         // Validate if updating
+        if (updates.totalBudget !== undefined && updates.totalBudget <= 0) {
+            return res.status(400).json({
+                success: false,
+                message: 'Valid total budget amount is required and must be greater than 0'
+            });
+        }
+
         if (updates.categories) {
             const totalPercentage = updates.categories.reduce((sum, cat) => sum + cat.percentage, 0);
             if (Math.abs(totalPercentage - 100) > 0.01) {
                 return res.status(400).json({
                     success: false,
                     message: `Total percentage must be 100%. Currently ${totalPercentage.toFixed(2)}%`
+                });
+            }
+
+            // Ensure we use the right totalBudget to compare against (either the new one or existing)
+            const expectedTotal = updates.totalBudget !== undefined ? updates.totalBudget : budget.totalBudget;
+            let totalAmount = 0;
+
+            for (const category of updates.categories) {
+                if (category.amount < 0) {
+                    return res.status(400).json({
+                        success: false,
+                        message: `Amount for ${category.name} cannot be negative`
+                    });
+                }
+                totalAmount += category.amount;
+            }
+
+            if (Math.abs(totalAmount - expectedTotal) > 0.01) {
+                return res.status(400).json({
+                    success: false,
+                    message: `Sum of category amounts (${totalAmount}) must equal total budget (${expectedTotal})`
                 });
             }
         }


### PR DESCRIPTION
## 📌 Description
 (Business Logic Validation Bypass in Budget Update allows Negative and Mismatched Budgets). 

Previously, the [updateBudget](cci:1://file:///c:/Coding%20Projects/Open%20Source/WalletWise/backend/controllers/budgetController.js:395:0-484:2) endpoint in [budgetController.js](cci:7://file:///c:/Coding%20Projects/Open%20Source/WalletWise/backend/controllers/budgetController.js:0:0-0:0) only checked that category percentages summed to 100%, completely omitting numeric checks on the actual budget amounts.

## 🛠 Changes Made
Added strict numeric validations to the [updateBudget](cci:1://file:///c:/Coding%20Projects/Open%20Source/WalletWise/backend/controllers/budgetController.js:395:0-484:2) endpoint matching the creation logic:
- Validates that `totalBudget` overrides are strictly greater than `0`.
- Validates that every individual category `amount` in the update payload is `>= 0`.
- Validates mathematically that the sum of the individual category amounts equals the targeted `totalBudget` to prevent mismatched allocations.



Reference #276
